### PR TITLE
Bugfix if func_args_str is dict

### DIFF
--- a/src/dolphin_mcp/client.py
+++ b/src/dolphin_mcp/client.py
@@ -432,7 +432,10 @@ async def process_tool_call(tc: Dict, servers: Dict[str, MCPClient], quiet_mode:
     try:
         func_args = json.loads(func_args_str)
     except:
-        func_args = {}
+        if isinstance(func_args_str, dict):
+            func_args = func_args_str
+        else:
+            func_args = {}
 
     parts = func_name.split("_", 1)
     if len(parts) != 2:


### PR DESCRIPTION
I am using dolphin-mcp with ollama.

Functioncalls not working with Parameters. I figured out that func_args_str is alread a dict, so json.dumps not working. 

I fixed this Issue