### PR TITLE
expand limit when running subprocess

### DIFF
--- a/src/dolphin_mcp/client.py
+++ b/src/dolphin_mcp/client.py
@@ -159,7 +159,8 @@ class MCPClient:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 env=env_vars,
-                cwd=self.cwd
+                cwd=self.cwd,
+                limit=1 << 20 # Set a larger buffer size for stdout
             )
             self.receive_task = asyncio.create_task(self._receive_loop())
             return await self._perform_initialize()


### PR DESCRIPTION
This pull request introduces a minor enhancement to the `start` method in `src/dolphin_mcp/client.py`. The change increases the buffer size for stdout to improve handling of larger outputs.

This is beneficial because the current buffer size is too small for some use cases, causing the subprocess to hang when the buffer is full.

* [`src/dolphin_mcp/client.py`](diffhunk://#diff-539c643a95d17b334aa7e1224aea28a97a8e56d2ea394e7d17e5d07aad65e80cL162-R163): Added a `limit` parameter to the `asyncio.create_subprocess_exec` call, setting a larger buffer size for stdout (`1 << 20`).

