### PR TITLE
non-localhost ollama server fix-  get ollama host from base_url

### DIFF
--- a/src/dolphin_mcp/providers/ollama.py
+++ b/src/dolphin_mcp/providers/ollama.py
@@ -520,8 +520,8 @@ async def call_ollama_api(
 
     # Determine host and construct URL
     host = DEFAULT_API_HOST
-    if client and hasattr(client, 'host'):
-        host = client.host
+    if client and hasattr(client._client, 'base_url'):
+        host = client._client.base_url
     api_url = f"{host}/api/chat"
     logger.debug(f"Target API URL: {api_url}")
 


### PR DESCRIPTION
Suspect someone's API changed- ollama? httpx?  Anyway this works :) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the method for determining the host URL used for Ollama API calls, improving compatibility with different client configurations. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->